### PR TITLE
Use a unix socket if on linux

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -65,6 +65,12 @@ module.exports = function start(_opts, output) {
     .then(() => common.findPort(result.cliPort+1))
     .then(port => {
         result.storagePort = port;
+        if(process.platform == 'linux'){
+            try{ // cleanup leftover sockets if nessesary
+                fs.unlinkSync('storage.sock')
+            }catch(e){}
+            result.storagePort = 'storage.sock'
+        }
 
         if(output) {
             try {


### PR DESCRIPTION
This uses a unix socket for the storage port if running on linux, in my tests, this produced a 2-3x tick speed increase even with multiple active bots going.