### PR TITLE
Improved start (async/await)

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -1,139 +1,170 @@
-var cp = require('child_process'),
+const cp = require('child_process'),
     path = require('path'),
     common = require('@screeps/common'),
     _ = require('lodash'),
     q = require('q'),
     ini = require('ini'),
+    util = require('util'),
     fs = require('fs');
 
-module.exports = function start(_opts, output) {
+const readFile = util.promisify(fs.readFile)
+const writeFile = util.promisify(fs.writeFile)
+const open = util.promisify(fs.open)
+const close = util.promisify(fs.close)
+const mkdir = util.promisify(fs.mkdir)
+const stat = util.promisify(fs.stat)
+const rename = util.promisify(fs.rename)
 
-    var opts = {};
+const DEFAULTS = {
+    modfile: 'mods.json',
+    runners_threads: 2,
+    processors_cnt: 2,
+    storage_timeout: 5000,
+    storage_enabled: true,
+    log_console: false,
+    log_rotate_keep: 5,
+    restart_interval: 3600
+}
+
+module.exports = async function start(_opts, output) {
+
+    let opts = {}
     try {
-        opts = ini.parse(fs.readFileSync('./.screepsrc', {encoding: 'utf8'}));
-    }
-    catch(e) {
-        if(e.code == 'ENOENT') {
+        opts = ini.parse(await readFile('./.screepsrc', {encoding: 'utf8'}));
+    } catch(e) {
+        if (e.code === 'ENOENT') {
             console.error(`Warning: file .screepsrc not found. Did you run "screeps init" in this directory?`);
         }
     }
-    for(var i in _opts) {
+    opts = Object.assign({}, DEFAULTS, opts);
+    for(let i in _opts) {
         if(_opts[i]) {
             opts[i] = _opts[i];
         }
     }
-    if(!opts.modfile) {
-        opts.modfile = 'mods.json';
-    }
     if(!opts.assetdir) {
-        throw new Error('`assetdir` option is not defined!')
-    }
-
-    if(!opts.runner_threads) {
-        opts.runner_threads = 2;
-    }
-    if(!opts.processors_cnt) {
-        opts.processors_cnt = 2;
+        throw new Error('`assetdir` option is not defined!');
     }
 
     try {
-        fs.statSync('./steam_appid.txt');
-    }
-    catch(e) {
-        fs.writeFileSync('./steam_appid.txt', '464350');
+        await stat('./steam_appid.txt');
+    } catch(e) {
+        await writeFile('./steam_appid.txt', '464350');
     }
 
-    var result = {
+    const result = {
         processes: {}
     };
 
-    return q.when()
-    .then(() => {
-        if(opts.port) {
-            result.gamePort = +opts.port;
-            return;
-        }
-        return common.findPort(21025).then(port => result.gamePort = port);
-    })
-    .then(() => {
-        if(opts.cli_port) {
-            result.cliPort = +opts.cli_port;
-            return;
-        }
-        return common.findPort(result.gamePort+1).then(port => result.cliPort = port);
-    })
-    .then(() => common.findPort(result.cliPort+1))
-    .then(port => {
-        result.storagePort = port;
+    if(opts.port) {
+        result.gamePort = +opts.port;
+    } else {
+        result.gamePort = await common.findPort(21025);
+    }
+    if(opts.cli_port) {
+        result.cliPort = +opts.cli_port;
+    } else {
+        result.cliPort = await common.findPort(result.gamePort+1);
+    }
+    if (opts.storage_port) {
+        result.storagePort = +opts.storage_port;
+    } else {
+        result.storagePort = await common.findPort(result.cliPort+1);
+    }
 
-        if(output) {
-            try {
-                output.write(`Server version ${require('screeps').version}\r\n`);
-            }
-            catch(e) {}
-            output.write(`Starting all processes. Ports: ${result.gamePort} (game), ${result.cliPort} (cli)\r\n`);
-        }
-
-
-        var timestamp = Date.now(), stat;
-
-        result.logdir = path.resolve(opts.logdir, ""+timestamp);
-
+    if(output) {
         try {
-            stat = fs.statSync(opts.logdir);
-        }
-        catch(e) {
-            fs.mkdirSync(opts.logdir);
-        }
-        if(stat && !stat.isDirectory()) {
+            output.write(`Server version ${require('screeps').version}\r\n`);
+        } catch(e) {}
+        output.write(`Starting all processes. Ports: ${result.gamePort} (game), ${result.cliPort} (cli)\r\n`);
+    }
+
+    try {
+       const statRes = await stat(opts.logdir);
+        if (!statRes.isDirectory()) {
             throw new Error(opts.logdir+' is not a directory!');
         }
+    } catch(e) {
+        await mkdir(opts.logdir);
+    }
 
-        fs.mkdirSync(result.logdir);
+    async function rotateLogs (logPath) {
+        for(let i = opts.log_rotate_keep; i > 1; i--) {
+            const oldName = `${logPath}.${i - 1}`
+            const newName = `${logPath}.${i}`
 
+            try {
+                await rename(oldName, newName)
+            } catch(e) {}
+        }
+        try {
+            await rename(logPath, `${logPath}.1`)
+        } catch(e) {}
+    }
 
-        function _startProcess(name, execPath, env) {
-            var fd = fs.openSync(path.resolve(result.logdir, name+'.log'), 'a');
+    async function _startProcess(name, execPath, env, restartInterval = 0) {
+        const logPath = path.resolve(opts.logdir, name+'.log')
+        await rotateLogs(logPath)
+        var str = fs.createWriteStream(logPath, 'utf-8');
 
             result.processes[name] = cp.fork(path.resolve(execPath), {
-                stdio: [0, fd, fd, 'ipc'],
+            stdio: [0, 'pipe', 'pipe', 'ipc'],
                 env: Object.assign(env, process.env)
             });
+        result.processes[name].stdout.pipe(str);
+        result.processes[name].stderr.pipe(str);
 
-            if(output) {
-                output.write(`[${name}] process ${result.processes[name].pid} started\r\n` );
-            }
-
-            result.processes[name].on('exit', code => {
-                if(output) {
-                    output.write(`[${name}] process ${result.processes[name].pid} exited with code ${code}, see 'logs' folder for more details\r\n` );
-                }
-                fs.closeSync(fd);
-                setTimeout(() => _startProcess(name, execPath, env), 1000);
-            });
-
-            return result.processes[name];
+        if (opts.log_console) {
+            result.processes[name].stdout.on('data', data => output.write(`[${name}] ${data.toString()}`))
+            result.processes[name].stderr.on('data', data => output.write(`[${name}] ${data.toString()}`))
         }
 
-        var errorTimeout = setTimeout(() => {
-            throw new Error('Could not launch the storage process');
-        }, 5000);
+        if(output) {
+            output.write(`[${name}] process ${result.processes[name].pid} started\r\n` );
+        }
 
-        var defer = q.defer();
+        if (restartInterval) {
+            setTimeout(() => result.processes[name].kill(), restartInterval * 1000)
+        }
 
-        var storageProcess = _startProcess('storage',
+        result.processes[name].on('exit', async code => {
+            if(output) {
+                output.write(`[${name}] process ${result.processes[name].pid} exited with code ${code}, restarting...\r\n` );
+            }
+            await str.close();
+            setTimeout(() => _startProcess(name, execPath, env), result.processes[name].killed ? 1 : 1000);
+        });
+        return result.processes[name];
+    }
+
+    function _waitForLaunch (storageProcess) {
+        return new Promise((resolve, reject) => {
+            const errorTimeout = setTimeout(() => {
+                reject(new Error('Could not launch the storage process'));
+            }, opts.storage_timeout);
+
+            const handler = (msg) => {
+                if (msg === 'storageLaunched') {
+                    clearTimeout(errorTimeout)
+                    storageProcess.removeListener('message', handler);
+                    resolve();
+                }
+            };
+            storageProcess.on('message', handler);
+        })
+    }
+
+    if (opts.storage_enabled) {
+        const storageProcess = await _startProcess('storage',
             path.resolve(path.dirname(require.resolve('@screeps/storage')), '../bin/start.js'), {
             STORAGE_PORT: result.storagePort,
             MODFILE: opts.modfile,
             DB_PATH: opts.db
         });
+        await _waitForLaunch(storageProcess)
+    }
 
-        storageProcess.on('message', message => {
-            if(message == 'storageLaunched') {
-
-                clearTimeout(errorTimeout);
-
-                _startProcess('backend',
+    await _startProcess('backend',
                     path.resolve(path.dirname(require.resolve('@screeps/backend')), '../bin/start.js'), {
                         GAME_PORT: result.gamePort,
                         GAME_HOST: opts.host,
@@ -146,34 +177,29 @@ module.exports = function start(_opts, output) {
                         STEAM_KEY: opts.steam_api_key
                     });
 
-                _startProcess('engine_main',
+    await _startProcess('engine_main',
                     path.resolve(path.dirname(require.resolve('@screeps/engine')), 'main.js'), {
                         STORAGE_PORT: result.storagePort,
                         MODFILE: opts.modfile,
                         DRIVER_MODULE: '@screeps/driver'
                     });
 
-                _startProcess('engine_runner',
-                    path.resolve(path.dirname(require.resolve('@screeps/engine')), 'runner.js'), {
-                        STORAGE_PORT: result.storagePort,
-                        MODFILE: opts.modfile,
-                        DRIVER_MODULE: '@screeps/driver',
-                        RUNNER_THREADS: opts.runner_threads
-                    });
+    for(var i=1; i<=opts.runners_cnt; i++) {
+        await _startProcess('engine_runner'+i,
+                        path.resolve(path.dirname(require.resolve('@screeps/engine')), 'runner.js'), {
+                            STORAGE_PORT: result.storagePort,
+                            MODFILE: opts.modfile,
+                            DRIVER_MODULE: '@screeps/driver',
+                            RUNNER_THREADS: opts.runner_threads
+                        }, opts.restart_interval);
+    }
 
-                for(var i=1; i<=opts.processors_cnt; i++) {
-                    _startProcess('engine_processor'+i,
+    for(var i=1; i<=opts.processors_cnt; i++) {
+        await _startProcess('engine_processor'+i,
                         path.resolve(path.dirname(require.resolve('@screeps/engine')), 'processor.js'), {
                             STORAGE_PORT: result.storagePort,
                             MODFILE: opts.modfile,
                             DRIVER_MODULE: '@screeps/driver'
-                        });
-                }
-
-                defer.resolve(result);
-            }
-        });
-
-        return defer.promise;
-    });
+                        }, opts.restart_interval);
+    }
 };


### PR DESCRIPTION
This is an improved version of the `start` part of the launcher.

It adds a few helpful features (forwarding console to terminal, better logging structure)
And also adds a few performance improving features (restart interval for runners/processors, option to disable storage when using alternative storage mods)
With Node 8, async/await runs natively, the code is restructured slightly to use them, this simplified some of the code and in general makes promises easier to work with. (I can try refactoring into a PR without async/await if this isn't desirable)

* Use async/await, this simplifies some of the code
* Added log_console option, forwards console messages to terminal
* Changed logs to use a rotating log rather than timestamps, this makes finding the most recent log much easier. (log_rotate_keep (default 5) controls how many to keep)
* Added a storage_enabled option (default true), this allows storage to be disabled when using a mod such as screepsmod-mongo
* Added restart_interval (default 3600 seconds (1hr)). This is the interval before runner and processors get restarted.